### PR TITLE
This simplifies the database retrival and superseeds existing method

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,9 @@ Automate the creation of Anki flashcards from the saved words stored in your Kob
 
 Assuming you have already enabled the beta feature **My Words**. If you have not or would like to, here is a [link](https://goodereader.com/blog/kobo-ereader-news/kobo-e-readers-now-save-words-you-looked-up-in-the-dictionary)
 
-Enabling the [developer option](https://goodereader.com/blog/kobo-ereader-news/how-to-access-the-secret-kobo-developer-options) on the Kobo ereader provides a variety of things, but the feature I am most interested in is FTP (File Transfer Protocol). We use FTP to copy the **KoboReader.sqlite** database from the ereader. Within this database there is a table, **WordList**, which stores the saved words. An api call is made to Merriam Webster to retrieve the word stems, definition and pronunciation if available. An api call is only made if a flashcard has not been created for that word.
+Within the database (**KoboReader.sqlite**) there is a table, **WordList**, which stores the saved words. An api call is made to Merriam Webster to retrieve the word stems, definition and pronunciation if available. An api call is only made if a flashcard has not been created for that word.
 
 **_Note:_**
-
-- By default there is no password for root or the ftp user! Assess your threat model if you are concerned!
 
 - When you save a word this does not update the **WordList** table. Through my testing it will only update if you do one of the following:
 
@@ -21,10 +19,9 @@ Enabling the [developer option](https://goodereader.com/blog/kobo-ereader-news/h
 ### Project file locations
 
 A path (**/home/username/.kobo-to-anki/**) is created which stores the following:
-- KoboReader.sqlite
-- Anki.sqlite
+- **Anki.sqlite**
 
-The first database is copy of what is on the ereader which is overwritten each time the script is executed. The second database will contain the words for which the flashcards have been created along with the word stems. Currently, the script creates flashcards for the **Head Word** (Company) and ignores the **Stems** (Companies, Companied, Companying). 
+The database will contain words for the flashcards that have been created along with the word stems. Currently, the script creates flashcards for the **Head Word** (Company) and ignores the **Stems** (Companies, Companied, Companying). 
 
 ### Example of flashcard
 ![Example](card_example.png)
@@ -45,21 +42,7 @@ The first database is copy of what is on the ereader which is overwritten each t
 
 2. Create a [merriam webster account](https://dictionaryapi.com/register/index). You want to ensure one out of the two api key requested is **Collegiate Dictionary**. You should then be able to login and see your api key
 
-3. Obtain the IP address of your ereader
-    
-    Go to your **Home** screen on your ereader
-
-    Tap the **More** icon at the bottom of the screen
-
-    Tap **Settings**
-
-    Tap **Device Information**
-
-    You will now see the IP address of your ereader
-    
-    Make a note of this for later use
-
-4. Run the following in your shell to install the project and dependencies:
+3. Run the following in your shell to install the project and dependencies:
 
     ```sh
     git clone https://github.com/WhoKanICan/kobo-to-anki.git
@@ -69,17 +52,14 @@ The first database is copy of what is on the ereader which is overwritten each t
 
     To install without git, download the source code from GitHub, extract the archive, and follow the steps above beginning from the second line.
 
-5.  Setting environment variables
+4.  Setting environment variables
     
-    While you are still in the kobo-to-anki directory issue the following commands in your shell
+    While you are still in the **kobo-to-anki** directory issue the following commands in your shell
 
     - replace <API_KEY> with the key you requested from step 2
 
-    - replace <IP_ADDRESS> with the IP address from step 3
-
     ```sh
     echo  "export MERRIAM_KEY=<API_KEY>" >> ~/.zshrc
-    echo  "export KOBO_IP_ADDRESS=<IP_ADDRESS>" >> ~/.zshrc
     echo  "export KOBO_TO_ANKI_PATH=${PWD}" >> ~/.zshrc
     source ~/.zshrc
     ```
@@ -88,15 +68,16 @@ The first database is copy of what is on the ereader which is overwritten each t
 
 ### Executing program
 
-Within the kobo-to-anki directory you issue
-```python
-python main.py
-```
-Once the flashcards have been created, Anki will be automatically synced and exited
+- Ensure your ereader is plugged in and mounted
+- Within the **kobo-to-anki** directory you issue
+    ```python
+    python main.py
+    ```
+Once the flashcards have been created, Anki will be automatically synced
 
 ### Uninstall
-You can remove the kobo-to-anki directory that stores the two .sqlite databases and delete the project downloaded
+You can remove the **kobo-to-anki** directory that stores the two .sqlite databases and delete the project downloaded
 
  ## TODO
-- [ ] Change method for retrieval of KoboReader.sqlite (security reasons)
-- [ ] Provide option to work via usb
+- [x] Change method for retrieval of KoboReader.sqlite (security reasons) ([#issue 5](https://github.com/WhoKanICan/kobo-to-anki/issues/5))
+- [x] Provide option to work via usb ([issue 5](https://github.com/WhoKanICan/kobo-to-anki/issues/5))

--- a/anki.py
+++ b/anki.py
@@ -1,18 +1,11 @@
 import subprocess
-import time
 
-def start() -> None:
-    """starts anki
+
+def start():
+    """
+    starts anki
     """
     subprocess.Popen(
-        "ps -C anki >/dev/null || anki >/dev/null",
-        shell=True
-    )
-
-def close() -> None:
-    """kills anki
-    """
-    subprocess.run(
-        "kill $(ps -C anki -o pid=)",
-        shell=True
+        "pgrep anki > /dev/null || anki > /dev/null",
+        shell=True,
     )

--- a/ereader.py
+++ b/ereader.py
@@ -1,30 +1,26 @@
-import ftplib
 from pathlib import Path
-import os
+import subprocess
 
 
-IP_ADDRESS = os.environ.get("EREADER_IP_ADDRESS")
-EREADER_DB_PATH = Path.home().joinpath(".kobo-to-anki/KoboReader.sqlite")
-
-def get_db() -> bool:
-    """copy the KoboReader.sqlite database from the reader
+def get_db_path() -> Path:
+    """
+    Return the KoboReader.sqlite path from the mount path
 
     Returns
     -------
-    bool
-        boolean returned depends on success of copying the KoboReader.sqlite database
+    Path
+        to the KoboReader.sqlite db path
+
+    Raises
+    ------
+    Exception
+        if Kobo reader can not be found
     """
-    ereader = ftplib.FTP()
-    try:
-        ereader.connect(IP_ADDRESS)
-        ereader.login("root","")
-        with open(EREADER_DB_PATH, 'wb') as fp:
-            ereader.retrbinary("RETR KoboReader.sqlite", fp.write)
-        ereader.quit()
-        return True
-    except ftplib.all_errors as e:
-        print(e)
-        return False
-    
-if __name__ == "__main__":
-    get_db()
+    db_path = subprocess.getoutput(
+        "df -h --output=target | grep -P '.*KOBOeReader'",
+    )
+    if not db_path:
+        raise Exception(
+            "Kobo Reader can not be found. Ensure device is plugged in and mounted"
+        )
+    return Path(db_path).joinpath(".kobo/KoboReader.sqlite")

--- a/main.py
+++ b/main.py
@@ -2,53 +2,50 @@ import ankiconnect
 import database
 import ereader
 import merriam
-import sys
-import string
 import anki
+from pathlib import Path
+
+ANKI_DB_PATH = Path.home().joinpath(".kobo-to-anki/Anki.sqlite")
+
 
 def main():
+    # query wordList table in KoboReader.sqlite
+    ereader_db_path = ereader.get_db_path()
+    ereader_db_connection = database.open(ereader_db_path)
+    ereader_saved_words = database.query_world_list(ereader_db_connection)
+    database.close(ereader_db_connection)
     # create Anki.sqlite db if it does not exists
-    database.is_created(database.ANKI_DB_PATH)
-
+    database.is_created(ANKI_DB_PATH)
+    # start and check services
+    anki.start()  # have this start then
+    ankiconnect.status()  # this can start. needs to be sync
+    ankiconnect.setup()
     # open db
-    anki_db = database.open(database.ANKI_DB_PATH)
-    ereader_db = database.open(ereader.EREADER_DB_PATH)
-        
-    # create schema to Anki.sqlite db if it does not exists
+    anki_db = database.open(ANKI_DB_PATH)
     database.create_table(anki_db, database.NOTES_TABLE_SCHEMA)
     database.create_table(anki_db, database.WORDS_TABLE_SCHEMA)
 
-    if not ankiconnect.status():
-        anki.start()
-        
-    # get the sqlite db from ereader
-    ereader.get_db()
-
-    # create deck and card model if not created
-    ankiconnect.setup()
-
     # database setup
-    for word, book, _, date_added in database.query(ereader_db):
-        word = word.lower().strip(string.punctuation)
-        exist = database.word_exist(anki_db, word)
-        if not exist:
+    for word, book, _, date_added in ereader_saved_words:
+        if not database.word_exist(anki_db, word):
             # api call
             data = merriam.get_word(word)
             parsed_data = merriam.parse(data)
             # unpack dict
-            word = parsed_data['word']
-            stem_set = parsed_data['stem_set']
+            word = parsed_data["word"]
+            stem_set = parsed_data["stem_set"]
             # create notes
             template = ankiconnect.create_note(parsed_data)
-            note_id = ankiconnect.invoke('addNote', **template)
+            note_id = ankiconnect.invoke("addNote", **template)
             # update notes and words table
             database.update_notes(anki_db, word, note_id, book, date_added)
             database.update_words(anki_db, word, stem_set)
     # close db
     database.close(anki_db)
-    database.close(ereader_db)
+    database.close(ereader_db_connection)
     # sync
-    ankiconnect.invoke('sync')
+    ankiconnect.invoke("sync")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
KoboReader.sqlite was retrieved using FTP (File Transfer Protocol) which needed to be enabled using the developer option within the ereader. This posed a security concern due to it not having a password. Method has been replaced using a wired connection. Documentation has been updated.

Because of this change I have renamed the get_db() function to [get_db_path().](https://github.com/WhoKanICan/kobo-to-anki/blob/52b6a5d69c4505e3094c80afe05f95820831173e/ereader.py#L5). This returns a path which ties in well with [database.open()](https://github.com/WhoKanICan/kobo-to-anki/blob/52b6a5d69c4505e3094c80afe05f95820831173e/database.py#L43)

Other changes to note:
[anki.close()](https://github.com/WhoKanICan/kobo-to-anki/blob/52b6a5d69c4505e3094c80afe05f95820831173e/anki.py#L4) function obsolete as user might want Anki open to review the cards
[ankiconnect.status() ](https://github.com/WhoKanICan/kobo-to-anki/blob/52b6a5d69c4505e3094c80afe05f95820831173e/ankiconnect.py#L49)function has retry attempt to match changes in main.py
README.md update to reflect changes of wired connection
format of code changed

fixes issue #5